### PR TITLE
Avoid arguments

### DIFF
--- a/Frameworks/OJUnit/OJTestRunnerText.j
+++ b/Frameworks/OJUnit/OJTestRunnerText.j
@@ -86,9 +86,9 @@ var stream = require("narwhal/term").stream;
     // do nothing. This is for subclassing purposes.
 }
 
-- (CPString)nextTest:(CPArray)arguments
+- (CPString)nextTest:(CPArray)args
 {
-    return require("file").absolute(arguments.shift());
+    return require("file").absolute(args.shift());
 }
 
 - (OJTestResult)run:(OJTest)suite wait:(BOOL)wait


### PR DESCRIPTION
arguments at here is type of Arguments on my computer. The first item is
an instance of OJTestRunnerText. The -nextTest: method got wrong file and then raise TypeError: 'undefined' is not a function.

I don't know why it cannot override internal arguments. If this isn't a common issus. Plz ignore this pull request.
