### PR TITLE
Replace all arguments by args. Fixed most tests of OJTest.

### DIFF
--- a/Frameworks/OJMoq/OJMoq.j
+++ b/Frameworks/OJMoq/OJMoq.j
@@ -85,9 +85,9 @@ function moq(baseObject)
      @param arguments Arguments for the selector. If an empty array of arguments is passed in, 
           then the selector matches all arguments.
  */
-- (OJMoq)selector:(SEL)selector times:(CPNumber)times arguments:(CPArray)arguments   
+- (OJMoq)selector:(SEL)selector times:(CPNumber)times arguments:(CPArray)args   
 {
-    theSelector = __ojmoq_findUniqueSelector(selector, arguments, selectors);
+    theSelector = __ojmoq_findUniqueSelector(selector, args, selectors);
     if(theSelector)
     {
     	var expectationFunction = function(){[OJMoqAssert selector:theSelector hasBeenCalled:times];};
@@ -95,7 +95,7 @@ function moq(baseObject)
     }
     else
     {
-    	var aSelector = [[OJMoqSelector alloc] initWithName:sel_getName(selector) withArguments:arguments];
+    	var aSelector = [[OJMoqSelector alloc] initWithName:sel_getName(selector) withArguments:args];
     	var expectationFunction = function(){[OJMoqAssert selector:aSelector hasBeenCalled:times];};
         [expectations addObject:expectationFunction];
     	[selectors addObject:aSelector];
@@ -121,16 +121,16 @@ function moq(baseObject)
      @param arguments The arguments that must be passed to selector for this to work
      @param value The value that the selector should return
  */
-- (OJMoq)selector:(SEL)aSelector returns:(CPObject)value arguments:(CPArray)arguments
+- (OJMoq)selector:(SEL)aSelector returns:(CPObject)value arguments:(CPArray)args
 {
-    var theSelector = __ojmoq_findUniqueSelector(aSelector, arguments, selectors);
+    var theSelector = __ojmoq_findUniqueSelector(aSelector, args, selectors);
     if(theSelector)
     {
         [theSelector setReturnValue:value];
     }
     else
     {
-        var aNewSelector = [[OJMoqSelector alloc] initWithName:sel_getName(aSelector) withArguments:arguments];
+        var aNewSelector = [[OJMoqSelector alloc] initWithName:sel_getName(aSelector) withArguments:args];
         [aNewSelector setReturnValue:value];
         [selectors addObject:aNewSelector];
     }
@@ -156,9 +156,9 @@ function moq(baseObject)
       @param aCallback A single-argument function that is passed the array of arguments
       @param arguments The arguments that the selector must match
  */
-- (OJMoq)selector:(SEL)aSelector callback:(Function)aCallback arguments:(CPArray)arguments
+- (OJMoq)selector:(SEL)aSelector callback:(Function)aCallback arguments:(CPArray)args
 {
-    var theSelector = __ojmoq_findUniqueSelector(aSelector, arguments, selectors);
+    var theSelector = __ojmoq_findUniqueSelector(aSelector, args, selectors);
     
     if(theSelector)
     {
@@ -166,7 +166,7 @@ function moq(baseObject)
     }
     else
     {
-        var aNewSelector = [[OJMoqSelector alloc] initWithName:sel_getName(aSelector) withArguments:arguments];
+        var aNewSelector = [[OJMoqSelector alloc] initWithName:sel_getName(aSelector) withArguments:args];
         [aNewSelector setCallback:aCallback];
         [selectors addObject:aNewSelector];
     }

--- a/Frameworks/OJMoq/OJMoqMock.j
+++ b/Frameworks/OJMoq/OJMoqMock.j
@@ -31,9 +31,9 @@ function mock(obj) {
 	[self selector:aSelector times:times arguments:[CPArray array]];
 }
 
-- (void)selector:(SEL)aSelector times:(CPNumber)times arguments:(CPArray)arguments
+- (void)selector:(SEL)aSelector times:(CPNumber)times arguments:(CPArray)args
 {
-	var selector = [self findOrCreateSelector:aSelector withArguments:arguments];
+	var selector = [self findOrCreateSelector:aSelector withArguments:args];
 	[expectations addObject:function(){[OJMoqAssert selector:selector hasBeenCalled:times];}];
 }
 
@@ -42,9 +42,9 @@ function mock(obj) {
 	[self selector:aSelector returns:returnValue arguments:[CPArray array]];
 }
 
-- (void)selector:(SEL)aSelector returns:(id)returnValue arguments:(CPArray)arguments
+- (void)selector:(SEL)aSelector returns:(id)returnValue arguments:(CPArray)args
 {
-	[[self findOrCreateSelector:aSelector withArguments:arguments] setReturnValue:returnValue];
+	[[self findOrCreateSelector:aSelector withArguments:args] setReturnValue:returnValue];
 }
 
 - (void)selector:(SEL)aSelector callback:(Function)callback
@@ -52,9 +52,9 @@ function mock(obj) {
 	[self selector:aSelector callback:callback arguments:[CPArray array]];
 }
 
-- (void)selector:(SEL)aSelector callback:(Function)callback arguments:(CPArray)arguments
+- (void)selector:(SEL)aSelector callback:(Function)callback arguments:(CPArray)args
 {
-	[[self findOrCreateSelector:aSelector withArguments:arguments] setCallback:callback];
+	[[self findOrCreateSelector:aSelector withArguments:args] setCallback:callback];
 }
 
 - (void)verifyThatAllExpectationsHaveBeenMet
@@ -62,10 +62,10 @@ function mock(obj) {
 	expectations.forEach(function(expectation){expectation();});
 }
 
-- (OJMoqSelector)findOrCreateSelector:(SEL)aSelector withArguments:(CPArray)arguments
+- (OJMoqSelector)findOrCreateSelector:(SEL)aSelector withArguments:(CPArray)args
 {
 	var foundSelectors = [OJMoqSelector find:[[OJMoqSelector alloc] initWithName:sel_getName(aSelector) 
-																	withArguments:arguments] 
+																	withArguments:args] 
 	                                    in:selectors ignoreWildcards:NO],
 	    selector = nil;
 	
@@ -74,7 +74,7 @@ function mock(obj) {
     else if ([foundSelectors count] === 1)
         selector = foundSelectors[0];
     else {
-        selector = [[OJMoqSelector alloc] initWithName:aSelector withArguments:arguments];
+        selector = [[OJMoqSelector alloc] initWithName:aSelector withArguments:args];
 		[selectors addObject:selector];
 	}
 

--- a/Frameworks/OJMoq/OJMoqSpy.j
+++ b/Frameworks/OJMoq/OJMoqSpy.j
@@ -40,11 +40,11 @@ function spy(obj)
 	[self selector:selector times:times arguments:[]];
 }
 
-- (void)selector:(SEL)selector times:(CPNumber)times arguments:(CPArray)arguments
+- (void)selector:(SEL)selector times:(CPNumber)times arguments:(CPArray)args
 {
 	[self replaceMethod:selector];
 
-   	var aSelector = [[OJMoqSelector alloc] initWithName:sel_getName(selector) withArguments:arguments];
+   	var aSelector = [[OJMoqSelector alloc] initWithName:sel_getName(selector) withArguments:args];
    	var expectationFunction = function(){[OJMoqAssert selector:aSelector hasBeenCalled:times];};
     [expectations addObject:expectationFunction];
    	[selectors addObject:aSelector];


### PR DESCRIPTION
I have run tests in `OJTest/Test/*.j`. These errors has been fixed. I left 3 failures because it's unimplemented functions.

But what about this issus?
In webkit console, narwhal console, objj console. Arguments name can overwrite internal variable.

``` javascript
    (function(arguments) { console.log(arguments); })(1)
    1

    $ js
    Narwhal version 0.2a, JavaScriptCore engine
    > (function(arguments) { print(arguments); })(1)
    1

    $ objj
    objj> (function(arguments) { print(arguments); })(1)
    1
```
