### PR TITLE
New: OJTestCase calls a setUp and tearDown class

### DIFF
--- a/Frameworks/OJUnit/OJTestCase.j
+++ b/Frameworks/OJUnit/OJTestCase.j
@@ -75,6 +75,22 @@
 }
 
 /*!
+    Called the setUpClass
+*/
+- (void)setUpClass
+{
+    [[self class] setUp]
+}
+
+/*!
+    Called the tearDownClass
+*/
+- (void)tearDownClass
+{
+    [[self class] tearDown]
+}
+
+/*!
    If the selector is not null,
    @param a parameter
  */
@@ -96,6 +112,20 @@
    TearDown method that is called after each run.
  */
 - (void)tearDown
+{
+}
+
+/*!
+   SetUp method that is called once before launching the test
+ */
++ (void)setUp
+{
+}
+
+/*!
+   TearDown method that is called once after launching the test
+ */
++ (void)tearDown
 {
 }
 

--- a/Frameworks/OJUnit/OJTestSuite.j
+++ b/Frameworks/OJUnit/OJTestSuite.j
@@ -153,10 +153,16 @@
 {
     for (var i = 0; i < _tests.length; i++)
     {
+        if (i == 0)
+            [_tests[i] setUpClass];
+
         if ([result shouldStop])
             break;
 
         [_tests[i] run:result];
+
+        if (i == (_tests.length - 1))
+            [_tests[i] tearDownClass];
     }
 }
 


### PR DESCRIPTION
Previously, OJTest didn't call a setUp or tearDown class. Now it does.
When launching the test, the methods +(void)setUp will be called once.
When all of the tests are finished, the methods +(void)tearDown will be called once.
