### PR TITLE
Formatting: Errant semicolon

### DIFF
--- a/Frameworks/OJUnit/OJTestSuite.j
+++ b/Frameworks/OJUnit/OJTestSuite.j
@@ -35,7 +35,7 @@ var DEFAULT_REGEX = @".*";
     return [self initWithClass:aClass selectorRegex:DEFAULT_REGEX];
 }
 
-- (id)initWithClass:(Class)aClass selectorRegex:(CPString)selectorRegex;
+- (id)initWithClass:(Class)aClass selectorRegex:(CPString)selectorRegex
 {
     if (self = [self init])
     {


### PR DESCRIPTION
This fix removes an errant semicolon at the end of the function definition.
