### PR TITLE
Use runtime function instead of accessing name directly

### DIFF
--- a/Frameworks/OJCov/OJCoverageListener.j
+++ b/Frameworks/OJCov/OJCoverageListener.j
@@ -90,7 +90,7 @@ SHOULD_APPEND = YES;
     class_addMethod = function(aClass, aName, anImplementation, aType) {
         if(aClass != null)
         {
-            var resolvedClass = objj_getClass(aClass.name);
+            var resolvedClass = objj_getClass(class_getName(aClass));
             [delegate foundMethod:[OJCoverageSelector selectorWithClassName:resolvedClass selector:aName]];
         }
 
@@ -100,9 +100,9 @@ SHOULD_APPEND = YES;
     class_addMethods = function(aClass, methods) {
         if(aClass != null)
         {
-            var resolvedClass = objj_getClass(aClass.name);
+            var resolvedClass = objj_getClass(class_getName(aClass));
             methods.map(function(method){[delegate foundMethod:[OJCoverageSelector
-                selectorWithClassName:resolvedClass selector:method.name]];});
+                selectorWithClassName:resolvedClass selector:method_getName(method)]];});
         }
 
         og_class_addMethods.apply(this, arguments);

--- a/Frameworks/OJUnit/OJTestSuite.j
+++ b/Frameworks/OJUnit/OJTestSuite.j
@@ -50,7 +50,7 @@ var DEFAULT_REGEX = @".*";
 
             for (var i = 0; i < methods.length; i++)
             {
-                [self addTestMethod:methods[i].name names:names class:aClass]
+                [self addTestMethod:method_getName(methods[i]) names:names class:aClass]
             }
 
             var autotestObject;
@@ -81,7 +81,7 @@ var DEFAULT_REGEX = @".*";
         if (ivars[i].accessors)
         {
             var getAccessorName = ivars[i].accessors.get,
-                ivarName = ivars[i].name,
+                ivarName = ivar_getName(ivars[i]),
                 newMethodName = "testThat__" + ivars[i].accessors.get + "__WorksIn" + [autotestObject class];
 
             class_addMethod(aClass, newMethodName, function(){

--- a/Frameworks/OJUnit/OJTestSuite.j
+++ b/Frameworks/OJUnit/OJTestSuite.j
@@ -56,7 +56,7 @@ var DEFAULT_REGEX = @".*";
             var autotestObject;
 
             if ([aClass respondsToSelector:@selector(autotest)])
-                autotestObject = objj_msgSend(aClass, "autotest");
+                autotestObject = [aClass autotest];
 
             if (autotestObject && ![_testClassesRan containsObject:aClass])
             {


### PR DESCRIPTION
To make OJTest more compliant to changes in the runtime